### PR TITLE
Update FAIR data during new GU action hook

### DIFF
--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -7,8 +7,8 @@ use Elliptic\EC\KeyPair;
 use MiniFAIR\PLC;
 use MiniFAIR\PLC\DID;
 use MiniFAIR\PLC\Util;
-use WP_Error;
 use stdClass;
+use WP_Error;
 
 function bootstrap() : void {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_load' );


### PR DESCRIPTION
Update to use new action hook in GU to consistently get latest data for FAIR. This should fix issue with not populating `signature` or `checksum` in `versions` data.

Will need testing in actual environment.