### PR TITLE
Add Caching for `wp_remote_get()`

### DIFF
--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -132,10 +132,9 @@ function generate_artifact_metadata( DID $did, $url ) {
 	$res = get_cache_data( $url );
 	if ( ! $res ) {
 		$res = wp_remote_get( $url, $opt );
-	}
-	if ( is_wp_error( $res ) ) {
-		return $res;
-	} else {
+		if ( is_wp_error( $res ) ) {
+			return $res;
+		}
 		set_cache_data( $res, $url );
 	}
 


### PR DESCRIPTION
Adds a 12 hour cache for `wp_remote_get()` calls in `generate_artifact_metadata()`.

It seems that otherwise `generate_artifacti_metadata()` will be called for every version on every page load.

Fixes #10 