### PR TITLE
Use Ed25519 for signing keys

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -338,8 +338,13 @@ function render_edit_page( WP_Post $post ) {
 					<?php
 					$verification_keys = $did->get_verification_keys();
 					foreach ( $verification_keys as $key ) : ?>
+						<?php
+						$public = $key->encode_public();
+						$id = substr( hash( 'sha256', $public ), 0, 6 );
+						?>
 						<li>
-							<code><?php echo esc_html( $key->encode_public() ); ?></code>
+							<code>fair_<?= esc_html( $id ); ?></code>:
+							<code><?= esc_html( $public ); ?></code>
 							<form action="" method="post">
 								<?php wp_nonce_field( NONCE_PREFIX . ACTION_KEY_REVOKE ); ?>
 								<input type="hidden" name="post" value="<?= esc_attr( $post->ID ); ?>" />

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -2,6 +2,7 @@
 
 namespace MiniFAIR\Admin;
 
+use Exception;
 use MiniFAIR;
 use MiniFAIR\PLC\DID;
 use WP_Post;
@@ -288,7 +289,7 @@ function on_revoke_key( DID $did ) {
 		$did->save();
 		wp_redirect( get_edit_post_link( $did->get_internal_post_id(), 'raw' ) );
 		exit;
-	} catch ( \Exception $e ) {
+	} catch ( Exception $e ) {
 		var_dump( $e );
 		wp_die( $e->getMessage(), __( 'Error Syncing PLC DID', 'minifair' ), [ 'response' => 500 ] );
 	}

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -251,7 +251,7 @@ function render_edit_page( WP_Post $post ) {
 			<td>
 				<ol>
 					<?php foreach ( $did->get_rotation_keys() as $key ) : ?>
-						<li><code><?php echo esc_html( Keys\encode_public_key( $key, Keys\CURVE_K256 ) ); ?></code></li>
+						<li><code><?php echo esc_html( $key->encode_public() ); ?></code></li>
 					<?php endforeach; ?>
 				</ol>
 				<p class="description"><?php esc_html_e( 'Rotation keys are used to manage the DID itself.', 'minifair' ); ?></p>
@@ -264,7 +264,7 @@ function render_edit_page( WP_Post $post ) {
 			<td>
 				<ol>
 					<?php foreach ( $did->get_verification_keys() as $key ) : ?>
-						<li><code><?php echo esc_html( Keys\encode_public_key( $key, Keys\CURVE_K256 ) ); ?></code></li>
+						<li><code><?php echo esc_html( $key->encode_public() ); ?></code></li>
 					<?php endforeach; ?>
 				</ol>
 				<p class="description"><?php esc_html_e( 'Verification keys are used for package signing.', 'minifair' ); ?></p>

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -400,6 +400,22 @@ function render_edit_page( WP_Post $post ) {
 			</th>
 			<td>
 				<p><?php esc_html_e( 'If the service endpoint or keys have changed, you can resync to the PLC Directory.', 'minifair' ); ?></p>
+				<details>
+					<summary><?php esc_html_e( 'Expected changes', 'minifair' ); ?></summary>
+					<?php
+					$current = $remote;
+					unset( $current['@context'] );
+					$diff = wp_text_diff(
+						json_encode( $current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
+						json_encode( $did->get_expected_document(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES )
+					);
+					if ( empty( $diff ) ) {
+						echo '<p class="description">' . esc_html__( 'No changes detected. The PLC Directory is already up to date.', 'minifair' ) . '</p>';
+					} else {
+						echo '<div class="diff">' . $diff . '</div>';
+					}
+					?>
+				</details>
 				<form action="" method="post">
 					<?php wp_nonce_field( NONCE_PREFIX . ACTION_SYNC ); ?>
 					<input type="hidden" name="post" value="<?php echo esc_attr( $post->ID ); ?>" />

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -339,10 +339,11 @@ function render_edit_page( WP_Post $post ) {
 				<label for="recovery"><?php esc_html_e( 'Verification Public Keys', 'minifair' ); ?></label>
 			</th>
 			<td>
-				<p class="description"><?php esc_html_e( 'Verification keys are used for package signing.', 'minifair' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Verification keys are used for package signing. Your newest (last) key is used for signing, but older keys are still used for verification. Revoking any key will invalidate any older packages which may be cached, so should only be done after some time (such as a week) has passed.', 'minifair' ); ?></p>
 				<ol>
 					<?php
 					$verification_keys = $did->get_verification_keys();
+					$last = end( $verification_keys );
 					foreach ( $verification_keys as $key ) : ?>
 						<?php
 						$public = $key->encode_public();
@@ -353,6 +354,9 @@ function render_edit_page( WP_Post $post ) {
 							<code><?= esc_html( $public ); ?></code>
 							<?php if ( $key instanceof Keys\ECKey ) : ?>
 								<p><small><em>(Key is using outdated algorithm and should be replaced.)</em></small></p>
+							<?php endif; ?>
+							<?php if ( $key === $last ): ?>
+								<p><small><strong>Current</strong></small></p>
 							<?php endif; ?>
 
 							<form action="" method="post">

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -4,6 +4,7 @@ namespace MiniFAIR\Admin;
 
 use Exception;
 use MiniFAIR;
+use MiniFAIR\Keys;
 use MiniFAIR\PLC\DID;
 use WP_Post;
 
@@ -346,6 +347,10 @@ function render_edit_page( WP_Post $post ) {
 						<li>
 							<code>fair_<?= esc_html( $id ); ?></code>:
 							<code><?= esc_html( $public ); ?></code>
+							<?php if ( $key instanceof Keys\ECKey ) : ?>
+								<p><small><em>(Key is using outdated algorithm and should be replaced.)</em></small></p>
+							<?php endif; ?>
+
 							<form action="" method="post">
 								<?php wp_nonce_field( NONCE_PREFIX . ACTION_KEY_REVOKE ); ?>
 								<input type="hidden" name="post" value="<?= esc_attr( $post->ID ); ?>" />

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -99,9 +99,12 @@ function get_artifact_metadata( DID $did, $url ) {
 }
 
 /**
+ * @param DID $did
+ * @param string $url
+ * @param boolean $force_regenerate True to skip cache.
  * @return array|WP_Error
  */
-function generate_artifact_metadata( DID $did, $url ) {
+function generate_artifact_metadata( DID $did, string $url, $force_regenerate = false ) {
 	$keys = $did->get_verification_keys();
 	if ( empty( $keys ) ) {
 		return new WP_Error(
@@ -128,7 +131,7 @@ function generate_artifact_metadata( DID $did, $url ) {
 			'Accept' => 'application/octet-stream;q=1.0, */*;q=0.7',
 		],
 	];
-	if ( ! empty( $artifact_metadata ) && isset( $artifact_metadata['etag'] ) ) {
+	if ( ! $force_regenerate && ! empty( $artifact_metadata ) && isset( $artifact_metadata['etag'] ) ) {
 		$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 	}
 
@@ -137,7 +140,7 @@ function generate_artifact_metadata( DID $did, $url ) {
 		return $res;
 	}
 
-	if ( 304 === $res['response']['code'] ) {
+	if ( ! $force_regenerate && 304 === $res['response']['code'] ) {
 		// Not modified, no need to update.
 		return $artifact_metadata;
 	}

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -104,10 +104,21 @@ function get_artifact_metadata( DID $did, $url ) {
  * @return array|WP_Error
  */
 function generate_artifact_metadata( DID $did, $url ) {
-	$signing_key = $did->get_verification_keys()[0] ?? null;
-	if ( ! $signing_key ) {
-		var_dump( 'No signing key found for DID' );
-		return;
+	$keys = $did->get_verification_keys();
+	if ( empty( $keys ) ) {
+		return new WP_Error(
+			'minifair.generate_artifact_metadata.missing_keys',
+			__( 'No verification keys found for DID', 'minifair' )
+		);
+	}
+
+	// todo: make active key selectable
+	$signing_key = end( $keys );
+	if ( empty( $signing_key ) ) {
+		return new WP_Error(
+			'minifair.generate_artifact_metadata.missing_signing_key',
+			__( 'No signing key found for DID', 'minifair' )
+		);
 	}
 
 	$artifact_id = sprintf( '%s:%s', $did->id, substr( sha1( $url ), 0, 8 ) );

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -2,10 +2,8 @@
 
 namespace MiniFAIR\Git_Updater;
 
-
-use Elliptic\EC\KeyPair;
 use MiniFAIR;
-use MiniFAIR\PLC;
+use MiniFAIR\Keys\Key;
 use MiniFAIR\PLC\DID;
 use MiniFAIR\PLC\Util;
 use stdClass;
@@ -162,14 +160,12 @@ function generate_artifact_metadata( DID $did, $url ) {
 	return $next_metadata;
 }
 
-function sign_artifact_data( KeyPair $key, $data ) {
+function sign_artifact_data( Key $key, $data ) {
 	// Hash, then sign the hash.
 	$hash = hash( 'sha256', $data, false );
-	$signature = $key->sign( $hash, 'hex', [
-		'canonical' => true
-	] );
+	$signature = $key->sign( $hash );
 
 	// Convert to compact (IEEE-P1363) form, then to base64url.
-	$compact = hex2bin( PLC\signature_to_compact( $key->ec, $signature ) );
+	$compact = hex2bin( $signature );
 	return Util\base64url_encode( $compact );
 }

--- a/inc/keys/class-eckey.php
+++ b/inc/keys/class-eckey.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace MiniFAIR\Keys;
+
+use Elliptic\EC;
+use Elliptic\EC\KeyPair;
+use Elliptic\EC\Signature;
+use Elliptic\Utils;
+use Exception;
+use YOCLIB\Multiformats\Multibase\Multibase;
+
+class ECKey implements Key {
+	public function __construct(
+		protected KeyPair $keypair,
+		protected string $curve
+	) {
+	}
+
+	/**
+	 * Does this key represent a private key?
+	 *
+	 * @return bool True if the key is a private keypair, false if it is a public key.
+	 */
+	public function is_private() : bool {
+		return $this->keypair->getPrivate() !== null;
+	}
+
+	/**
+	 * Convert a keypair object to a multibase public key string.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @return string The multibase public key string (starts with z).
+	 */
+	public function encode_public() : string {
+		$pub = $this->keypair->getPublic( true, 'hex' );
+		$prefix = match ( $this->curve ) {
+			CURVE_K256 => bin2hex( PREFIX_CURVE_K256 ),
+			CURVE_P256 => bin2hex( PREFIX_CURVE_P256 ),
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $pub ) );
+		return $encoded;
+	}
+
+	/**
+	 * Convert a keypair object to a multibase private key string.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_private() : string {
+		if ( ! $this->is_private() ) {
+			throw new Exception( 'Cannot encode private key for a public key' );
+		}
+
+		$priv = $this->keypair->getPrivate( 'hex' );
+		$prefix = match ( $this->curve ) {
+			CURVE_K256 => bin2hex( PREFIX_CURVE_K256 ),
+			CURVE_P256 => bin2hex( PREFIX_CURVE_P256 ),
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $priv ));
+		return $encoded;
+	}
+
+	/**
+	 * Convert a signature to compact (IEEE-P1363) representation.
+	 *
+	 * (Equivalent to secp256k1_ecdsa_sign_compact().)
+	 *
+	 * @internal Elliptic does not support compact signatures, only DER-encoded, so
+	 *           we need to do it ourselves. Compact signatures are just the r and
+	 *           s bytes concatenated, but must be padded to 32 bytes each.
+	 *
+	 * @param EC $ec The elliptic curve object.
+	 * @param Signature $signature The signature object.
+	 * @return string The compact signature.
+	 */
+	protected function signature_to_compact( EC $ec, Signature $signature ) : string {
+		$byte_length = ceil( $ec->curve->n->bitLength() / 8 );
+		$compact = Utils::toHex( $signature->r->toArray( 'be', $byte_length ) ) . Utils::toHex( $signature->s->toArray( 'be', $byte_length ) );
+		return $compact;
+	}
+
+	/**
+	 * Sign data using the private key.
+	 *
+	 * @param string $data The data to sign, as a hex-encoded string.
+	 * @return string The signature encoded as a binary string.
+	 */
+	public function sign( string $data ) : string {
+		if ( ! $this->is_private() ) {
+			throw new Exception( 'Cannot sign with a public key' );
+		}
+
+		/**
+		 * Hash with SHA-256, then sign, using canonical (low-S) form.
+		 *
+		 * @var \Elliptic\EC\Signature
+		 */
+		$signature = $this->keypair->sign( $data, 'hex', [
+			'canonical' => true
+		] );
+
+		// Convert to compact (IEEE-P1363) form.
+		if ( $this->curve === CURVE_K256 ) {
+			return $this->signature_to_compact( $this->keypair->ec, $signature );
+		}
+		return $signature->toDER( 'hex' );
+	}
+
+	/**
+	 * Generate a new keypair.
+	 *
+	 * We use NIST K-256 as the default to match ATProto.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return static The generated keypair object.
+	 */
+	public static function generate( string $curve ) : static {
+		$ec = new EC( $curve );
+		return new static( $ec->genKeyPair(), $curve );
+	}
+
+	/**
+	 * Convert a multibase public key string to a keypair object.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @param string $key The multibase public key string (starts with z).
+	 * @return static The key object.
+	 */
+	public static function from_public( string $key ) : static {
+		$decoded = Multibase::decode( $key );
+
+		$curve = match ( substr( $decoded, 0, 2 ) ) {
+			PREFIX_CURVE_P256 => CURVE_P256,
+			PREFIX_CURVE_K256 => CURVE_K256,
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+
+		$ec = new EC( $curve );
+
+		$stripped = bin2hex( substr( $decoded, 2 ) );
+		$keypair = $ec->keyFromPublic( $stripped, 'hex' );
+		return new static( $keypair, $curve );
+	}
+
+	/**
+	 * Convert a multibase private key string to a keypair object.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @param string $key The multibase public key string (starts with z).
+	 * @return static The key object.
+	 */
+	public static function from_private( string $key ) : static {
+		$decoded = Multibase::decode( $key );
+
+		$curve = match ( substr( $decoded, 0, 2 ) ) {
+			PREFIX_CURVE_P256 => CURVE_P256,
+			PREFIX_CURVE_K256 => CURVE_K256,
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+
+		$ec = new EC( $curve );
+
+		$stripped = bin2hex( substr( $decoded, 2 ) );
+		$keypair = $ec->keyFromPrivate( $stripped, 'hex' );
+		return new static( $keypair, $curve );
+	}
+}

--- a/inc/keys/class-eckey.php
+++ b/inc/keys/class-eckey.php
@@ -105,6 +105,7 @@ class ECKey implements Key {
 		] );
 
 		// Convert to compact (IEEE-P1363) form.
+		// todo: do we need to do this for p256 too?
 		if ( $this->curve === CURVE_K256 ) {
 			return $this->signature_to_compact( $this->keypair->ec, $signature );
 		}

--- a/inc/keys/class-eckey.php
+++ b/inc/keys/class-eckey.php
@@ -57,8 +57,8 @@ class ECKey implements Key {
 
 		$priv = $this->keypair->getPrivate( 'hex' );
 		$prefix = match ( $this->curve ) {
-			CURVE_K256 => bin2hex( PREFIX_CURVE_K256 ),
-			CURVE_P256 => bin2hex( PREFIX_CURVE_P256 ),
+			CURVE_K256 => bin2hex( PREFIX_CURVE_K256_PRIVATE ),
+			CURVE_P256 => bin2hex( PREFIX_CURVE_P256_PRIVATE ),
 			default => throw new Exception( 'Unsupported curve' ),
 		};
 		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $priv ));
@@ -165,6 +165,10 @@ class ECKey implements Key {
 		$decoded = Multibase::decode( $key );
 
 		$curve = match ( substr( $decoded, 0, 2 ) ) {
+			PREFIX_CURVE_P256_PRIVATE => CURVE_P256,
+			PREFIX_CURVE_K256_PRIVATE = CURVE_K256,
+
+			// todo: Legacy, remove this later.
 			PREFIX_CURVE_P256 => CURVE_P256,
 			PREFIX_CURVE_K256 => CURVE_K256,
 			default => throw new Exception( 'Unsupported curve' ),

--- a/inc/keys/class-eckey.php
+++ b/inc/keys/class-eckey.php
@@ -166,7 +166,7 @@ class ECKey implements Key {
 
 		$curve = match ( substr( $decoded, 0, 2 ) ) {
 			PREFIX_CURVE_P256_PRIVATE => CURVE_P256,
-			PREFIX_CURVE_K256_PRIVATE = CURVE_K256,
+			PREFIX_CURVE_K256_PRIVATE => CURVE_K256,
 
 			// todo: Legacy, remove this later.
 			PREFIX_CURVE_P256 => CURVE_P256,

--- a/inc/keys/class-eckey.php
+++ b/inc/keys/class-eckey.php
@@ -66,6 +66,29 @@ class ECKey implements Key {
 	}
 
 	/**
+	 * Convert a key to an incorrectly-encoded key string.
+	 *
+	 * Used only for revocation.
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_private_legacy_do_not_use_or_you_will_be_fired() : string {
+		if ( ! $this->is_private() ) {
+			throw new Exception( 'Cannot encode private key for a public key' );
+		}
+
+		$priv = $this->keypair->getPrivate( 'hex' );
+		$prefix = match ( $this->curve ) {
+			CURVE_K256 => bin2hex( PREFIX_CURVE_K256 ),
+			CURVE_P256 => bin2hex( PREFIX_CURVE_P256 ),
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $priv ));
+		return $encoded;
+	}
+
+	/**
 	 * Convert a signature to compact (IEEE-P1363) representation.
 	 *
 	 * (Equivalent to secp256k1_ecdsa_sign_compact().)

--- a/inc/keys/class-eddsakey.php
+++ b/inc/keys/class-eddsakey.php
@@ -46,7 +46,7 @@ class EdDSAKey implements Key {
 	 * @return string The multibase private key string (starts with z).
 	 */
 	public function encode_public() : string {
-		$pub = $this->keypair->getPublic( true, 'hex' );
+		$pub = $this->keypair->getPublic( 'hex' );
 		$prefix = match ( $this->curve ) {
 			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519 ),
 			default => throw new Exception( 'Unsupported curve' ),
@@ -68,7 +68,7 @@ class EdDSAKey implements Key {
 			throw new Exception( 'Cannot encode private key for a public key' );
 		}
 
-		$priv = $this->keypair->getSecret( true, 'hex' );
+		$priv = $this->keypair->getSecret( 'hex' );
 		$prefix = match ( $this->curve ) {
 			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519 ),
 			default => throw new Exception( 'Unsupported curve' ),
@@ -89,7 +89,8 @@ class EdDSAKey implements Key {
 
 		// Convert to KeyPair object.
 		$ed = new EdDSA( $curve );
-		return new static( $ed->keyFromSecret( $secret ), $curve );
+		$key = $ed->keyFromSecret( bin2hex( $secret ) );
+		return new static( $key, $curve );
 	}
 
 	/**

--- a/inc/keys/class-eddsakey.php
+++ b/inc/keys/class-eddsakey.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace MiniFAIR\Keys;
+
+use Elliptic\EdDSA;
+use Elliptic\EdDSA\KeyPair;
+use Elliptic\EdDSA\Signature;
+use Exception;
+use YOCLIB\Multiformats\Multibase\Multibase;
+
+class EdDSAKey {
+	public function __construct(
+		protected KeyPair $keypair,
+		protected string $curve
+	) {
+	}
+
+	/**
+	 * Does this key represent a private key?
+	 *
+	 * @return bool True if the key is a private keypair, false if it is a public key.
+	 */
+	public function is_private() : bool {
+		return $this->keypair->secret() !== null;
+	}
+
+	/**
+	 * Sign data using the private key.
+	 *
+	 * @param string $data The data to sign, as a hex-encoded string.
+	 * @return string The signature encoded as a hex-encoded string.
+	 */
+	public function sign( string $data ) : string {
+		if ( ! $this->is_private() ) {
+			throw new Exception( 'Cannot sign with a public key' );
+		}
+
+		return $this->keypair->sign( $data )->toHex();
+	}
+
+	/**
+	 * Convert a key to a multibase private key string.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_public() : string {
+		$pub = $this->keypair->getPublic( true, 'hex' );
+		$prefix = match ( $this->curve ) {
+			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519 ),
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $pub ) );
+		return $encoded;
+	}
+
+	/**
+	 * Convert a key to a multibase private key string.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_private() : string {
+		if ( ! $this->is_private() ) {
+			throw new Exception( 'Cannot encode private key for a public key' );
+		}
+
+		$priv = $this->keypair->getSecret( true, 'hex' );
+		$prefix = match ( $this->curve ) {
+			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519 ),
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $priv ) );
+		return $encoded;
+	}
+
+	/**
+	 * Generate a new key.
+	 *
+	 * @return static A new instance of the key.
+	 */
+	public static function generate( string $curve ) : static {
+		// Generate a random keypair.
+		$key = sodium_crypto_sign_keypair();
+		$secret = sodium_crypto_sign_secretkey( $key );
+
+		// Convert to KeyPair object.
+		$ed = new EdDSA( $curve );
+		return new static( $ed->keyFromSecret( $secret ), $curve );
+	}
+
+	/**
+	 * Convert a multibase public key string to a keypair object.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @param string $key The multibase public key string (starts with z).
+	 * @return static The key object.
+	 */
+	public static function from_public( string $key ) : static {
+		$decoded = Multibase::decode( $key );
+
+		$curve = match ( substr( $decoded, 0, 2 ) ) {
+			PREFIX_CURVE_ED25519 => CURVE_ED25519,
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+
+		$eddsa = new EdDSA( $curve );
+
+		$stripped = bin2hex( substr( $decoded, 2 ) );
+		$keypair = $eddsa->keyFromPublic( $stripped, 'hex' );
+		return new static( $keypair, $curve );
+	}
+
+	/**
+	 * Convert a multibase private key string to a keypair object.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @param string $key The multibase public key string (starts with z).
+	 * @return static The key object.
+	 */
+	public static function from_private( string $key ) : static {
+		$decoded = Multibase::decode( $key );
+
+		$curve = match ( substr( $decoded, 0, 2 ) ) {
+			PREFIX_CURVE_ED25519 => CURVE_ED25519,
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+
+		$eddsa = new EdDSA( $curve );
+
+		$stripped = bin2hex( substr( $decoded, 2 ) );
+		$keypair = $eddsa->keyFromSecret( $stripped, 'hex' );
+		return new static( $keypair, $curve );
+	}
+}

--- a/inc/keys/class-eddsakey.php
+++ b/inc/keys/class-eddsakey.php
@@ -7,7 +7,7 @@ use Elliptic\EdDSA\KeyPair;
 use Exception;
 use YOCLIB\Multiformats\Multibase\Multibase;
 
-class EdDSAKey {
+class EdDSAKey implements Key {
 	public function __construct(
 		protected KeyPair $keypair,
 		protected string $curve

--- a/inc/keys/class-eddsakey.php
+++ b/inc/keys/class-eddsakey.php
@@ -4,7 +4,6 @@ namespace MiniFAIR\Keys;
 
 use Elliptic\EdDSA;
 use Elliptic\EdDSA\KeyPair;
-use Elliptic\EdDSA\Signature;
 use Exception;
 use YOCLIB\Multiformats\Multibase\Multibase;
 

--- a/inc/keys/class-eddsakey.php
+++ b/inc/keys/class-eddsakey.php
@@ -70,7 +70,7 @@ class EdDSAKey implements Key {
 
 		$priv = $this->keypair->getSecret( 'hex' );
 		$prefix = match ( $this->curve ) {
-			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519 ),
+			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519_PRIVATE ),
 			default => throw new Exception( 'Unsupported curve' ),
 		};
 		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $priv ) );
@@ -130,6 +130,9 @@ class EdDSAKey implements Key {
 		$decoded = Multibase::decode( $key );
 
 		$curve = match ( substr( $decoded, 0, 2 ) ) {
+			PREFIX_CURVE_ED25519_PRIVATE => CURVE_ED25519,
+
+			// todo: Legacy, remove this later.
 			PREFIX_CURVE_ED25519 => CURVE_ED25519,
 			default => throw new Exception( 'Unsupported curve' ),
 		};

--- a/inc/keys/class-eddsakey.php
+++ b/inc/keys/class-eddsakey.php
@@ -78,6 +78,28 @@ class EdDSAKey implements Key {
 	}
 
 	/**
+	 * Convert a key to an incorrectly-encoded key string.
+	 *
+	 * Used only for revocation.
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_private_legacy_do_not_use_or_you_will_be_fired() : string {
+		if ( ! $this->is_private() ) {
+			throw new Exception( 'Cannot encode private key for a public key' );
+		}
+
+		$priv = $this->keypair->getSecret( 'hex' );
+		$prefix = match ( $this->curve ) {
+			CURVE_ED25519 => bin2hex( PREFIX_CURVE_ED25519 ),
+			default => throw new Exception( 'Unsupported curve' ),
+		};
+		$encoded = Multibase::encode( Multibase::BASE58BTC, hex2bin( $prefix . $priv ) );
+		return $encoded;
+	}
+
+	/**
 	 * Generate a new key.
 	 *
 	 * @return static A new instance of the key.

--- a/inc/keys/class-key.php
+++ b/inc/keys/class-key.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace MiniFAIR\Keys;
+
+interface Key {
+	/**
+	 * Does this key represent a private key?
+	 *
+	 * @return bool True if the key is a private keypair, false if it is a public key.
+	 */
+	public function is_private() : bool;
+
+	/**
+	 * Sign data using the private key.
+	 *
+	 * @param string $data The data to sign, as a hex-encoded string.
+	 * @return string The signature encoded as a hex-encoded string.
+	 */
+	public function sign( string $data ) : string;
+
+	/**
+	 * Convert a key to a multibase private key string.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_public() : string;
+
+	/**
+	 * Convert a key to a multibase private key string.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @return string The multibase private key string (starts with z).
+	 */
+	public function encode_private() : string;
+
+	/**
+	 * Convert a multibase public key string to a key.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @param string $key The multibase public key string (starts with z).
+	 * @return Key The key object.
+	 */
+	public static function from_public( string $key ) : static;
+
+	/**
+	 * Convert a multibase private key string to a key.
+	 *
+	 * @see https://atproto.com/specs/cryptography
+	 *
+	 * @throws Exception If the curve is not supported.
+	 * @param string $key The multibase public key string (starts with z).
+	 * @return Key The key object.
+	 */
+	public static function from_private( string $key ) : static;
+}

--- a/inc/keys/namespace.php
+++ b/inc/keys/namespace.php
@@ -9,21 +9,15 @@ use YOCLIB\Multiformats\Multibase\Multibase;
 
 const CURVE_K256 = 'secp256k1';
 const CURVE_P256 = 'p256';
+const CURVE_ED25519 = 'ed25519';
 
-/**
- * Generate a new keypair.
- *
- * We use NIST K-256 as the default to match ATProto.
- *
- * @see https://atproto.com/specs/cryptography
- *
- * @throws Exception If the curve is not supported.
- * @return KeyPair The generated keypair object.
- */
-function generate_keypair() : KeyPair {
-	$ec = new EC( CURVE_K256 );
-	return $ec->genKeyPair();
-}
+// From https://github.com/multiformats/multicodec/blob/master/table.csv:
+// 0xe7 0x01 = varint( 0xe7 ) = 231 = secp256k1-pub
+// 0x80 0x24 = varint( 0x80 ) = 128 = p256-pub
+// 0xed 0x01 = varint( 0xed ) = 237 = ed25519-pub
+const PREFIX_CURVE_K256 = "\xe7\x01";
+const PREFIX_CURVE_P256 = "\x80\x24";
+const PREFIX_CURVE_ED25519 = "\xed\x01";
 
 /**
  * Convert a multibase public key string to a keypair object.

--- a/inc/keys/namespace.php
+++ b/inc/keys/namespace.php
@@ -15,9 +15,17 @@ const CURVE_ED25519 = 'ed25519';
 // 0xe7 0x01 = varint( 0xe7 ) = 231 = secp256k1-pub
 // 0x80 0x24 = varint( 0x80 ) = 128 = p256-pub
 // 0xed 0x01 = varint( 0xed ) = 237 = ed25519-pub
+// 0x81 0x26 = varint( 0x1301 ) = 4865 = secp256k1-priv
+// 0x86 0x26 = varint( 0x1306 ) = 4870 = p256-priv
+// 0x80 0x26 = varint( 0x1300 ) = 4864 = ed25519-priv
 const PREFIX_CURVE_K256 = "\xe7\x01";
+const PREFIX_CURVE_K256_PRIVATE = "\x81\x26";
 const PREFIX_CURVE_P256 = "\x80\x24";
+const PREFIX_CURVE_P256_PRIVATE = "\x06\x26";
+
+// https://www.w3.org/TR/vc-di-eddsa/#ed25519verificationkey2020
 const PREFIX_CURVE_ED25519 = "\xed\x01";
+const PREFIX_CURVE_ED25519_PRIVATE = "\x80\x26"; // 0x1300
 
 /**
  * Convert a multibase public key string to a keypair object.

--- a/inc/keys/namespace.php
+++ b/inc/keys/namespace.php
@@ -72,6 +72,11 @@ function decode_private_key( string $key ) : Key {
 	$decoded = Multibase::decode( $key );
 
 	$keypair = match ( substr( $decoded, 0, 2 ) ) {
+		PREFIX_CURVE_P256_PRIVATE => ECKey::from_private( $key ),
+		PREFIX_CURVE_K256_PRIVATE => ECKey::from_private( $key ),
+		PREFIX_CURVE_ED25519_PRIVATE => EdDSAKey::from_private( $key ),
+
+		// todo: Legacy, remove this later.
 		PREFIX_CURVE_P256    => ECKey::from_private( $key ),
 		PREFIX_CURVE_K256    => ECKey::from_private( $key ),
 		PREFIX_CURVE_ED25519 => EdDSAKey::from_private( $key ),

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -75,7 +75,7 @@ function update_metadata( DID $did, bool $force_regenerate = false ) {
  */
 function get_remote_url( $url, $opt = null ) {
 	$opt = $opt ?? [ 'headers' => [ 'Accept' => 'application/did+ld+json' ] ];
-	$cache_key = CACHE_PREFIX . sha1( $url );
+	$cache_key = CACHE_PREFIX . sha1( $url ) . sha1( serialize( $opt ) );
 	$response = wp_cache_get( $cache_key );
 	if ( ! $response ) {
 		$response = wp_remote_get( $url, $opt );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -54,6 +54,21 @@ function get_package_metadata( DID $did ) {
 }
 
 /**
+ * @param DID $did
+ * @param bool $force_regenerate
+ * @return bool|null
+ */
+function update_metadata( DID $did, bool $force_regenerate = false ) {
+	foreach ( get_providers() as $provider ) {
+		if ( $provider->is_authoritative( $did ) ) {
+			return $provider->update_metadata( $did, $force_regenerate );
+		}
+	}
+
+	return null;
+}
+
+/**
  * @param string $url URL.
  * @param array $opt wp_remote_get options.
  * @return array|WP_Error

--- a/inc/plc/class-canonicalmapobject.php
+++ b/inc/plc/class-canonicalmapobject.php
@@ -63,12 +63,14 @@ class CanonicalMapObject extends AbstractCBORObject implements Countable, Iterat
 
     public function __toString(): string
     {
-        uksort($this->data, function ($a, $b) {
-            if (strlen($a) === strlen($b) ) {
-                return strcmp($a, $b);
+        usort($this->data, function ($a, $b) {
+            $a_key = (string) $a->getKey();
+            $b_key = (string) $b->getKey();
+            if (strlen($a_key) === strlen($b_key) ) {
+                return strcmp($a_key, $b_key);
             }
 
-            return strlen($a) <=> strlen($b);
+            return strlen($a_key) <=> strlen($b_key);
         });
 
         $result = parent::__toString();

--- a/inc/plc/class-command.php
+++ b/inc/plc/class-command.php
@@ -20,7 +20,7 @@ class Command extends WP_CLI_Command {
 
 		$rot_keys = $did->get_rotation_keys();
 		foreach ( $rot_keys as $key ) {
-			$encoded = Keys\encode_public_key( $key, Keys\CURVE_K256 );
+			$encoded = $key->encode_public();
 			printf(
 				"Rotation key:     %s\n",
 				$encoded
@@ -28,7 +28,7 @@ class Command extends WP_CLI_Command {
 		}
 		$verif_keys = $did->get_verification_keys();
 		foreach ( $verif_keys as $key ) {
-			$encoded = Keys\encode_public_key( $key, Keys\CURVE_K256 );
+			$encoded = $key->encode_public();
 			printf(
 				"Verification key: %s\n",
 				$encoded
@@ -48,7 +48,7 @@ class Command extends WP_CLI_Command {
 
 		$rot_keys = $did->get_rotation_keys();
 		foreach ( $rot_keys as $key ) {
-			$encoded = Keys\encode_public_key( $key, Keys\CURVE_K256 );
+			$encoded = $key->encode_public();
 			printf(
 				"Rotation key:     %s\n",
 				$encoded
@@ -56,7 +56,7 @@ class Command extends WP_CLI_Command {
 		}
 		$verif_keys = $did->get_verification_keys();
 		foreach ( $verif_keys as $key ) {
-			$encoded = Keys\encode_public_key( $key, Keys\CURVE_K256 );
+			$encoded = $key->encode_public();
 			printf(
 				"Verification key: %s\n",
 				$encoded

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -143,7 +143,7 @@ class DID {
 			throw new \Exception( 'Error performing operation: ' . wp_remote_retrieve_body( $response ) );
 		}
 
-		var_dump( $response );
+		return true;
 	}
 
 	public function update() {
@@ -345,7 +345,7 @@ class DID {
 		];
 
 		// Generate an initial keypair for verification.
-		$verification_key = $did->generate_verification_key();
+		$did->generate_verification_key();
 
 		// Create the genesis operation.
 		$genesis_unsigned = new Operation(

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -157,6 +157,16 @@ class DID {
 		return $this->perform_operation( $op );
 	}
 
+	public function get_expected_document() : array {
+		$op = $this->prepare_update_op();
+		if ( ! $op ) {
+			$op = $this->fetch_last_op();
+		}
+
+		// Convert the operation to a document.
+		return operation_to_did_document( $this->id, $op );
+	}
+
 	/**
 	 * Prepare the verification keys for the operation.
 	 *

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -165,12 +165,16 @@ class DID {
 		$last_cid = cid_for_operation( $last_op );
 
 		// Merge prior data with current data.
+		$verification_keys = [];
+		foreach ( $this->get_verification_keys() as $key ) {
+			$key_id = substr( hash( 'sha256', $key->encode_public() ), 0, 6 );
+			$verification_keys[ 'fair_' . $key_id ] = $key;
+		}
+
 		$update_unsigned = new Operation(
 			type: 'plc_operation',
 			rotationKeys: $this->get_rotation_keys(),
-			verificationMethods: [
-				VERIFICATION_METHOD_ID => $this->get_verification_keys()[0],
-			],
+			verificationMethods: $verification_keys,
 			alsoKnownAs: $last_op->alsoKnownAs,
 			services: [
 				'fairpm_repo' => [

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -67,15 +67,8 @@ class DID {
 
 		if ( ! in_array( $encoded, $this->verification_keys, true ) ) {
 			// Check for legacy-encoded keys too.
-			if ( str_starts_with( $encoded, Keys\PREFIX_CURVE_K256_PRIVATE ) ) {
-				$legacy_encoded = Keys\PREFIX_CURVE_K256 . substr( $encoded, strlen( Keys\PREFIX_CURVE_K256_PRIVATE ) );
-				if ( ! in_array( $legacy_encoded, $this->verification_keys, true ) ) {
-					return false;
-				}
-				$encoded = $legacy_encoded;
-			}
-			elseif ( str_starts_with( $encoded, Keys\PREFIX_CURVE_ED25519_PRIVATE ) ) {
-				$legacy_encoded = Keys\PREFIX_CURVE_ED25519 . substr( $encoded, strlen( Keys\PREFIX_CURVE_ED25519_PRIVATE ) );
+			if ( method_exists( $key, 'encode_private_legacy_do_not_use_or_you_will_be_fired' ) ) {
+				$legacy_encoded = $key->encode_private_legacy_do_not_use_or_you_will_be_fired();
 				if ( ! in_array( $legacy_encoded, $this->verification_keys, true ) ) {
 					return false;
 				}

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -79,7 +79,7 @@ class DID {
 			}
 		}
 
-		$this->verification_keys = array_filter( $this->verification_keys, fn ( $k ) => $k !== $encoded );
+		$this->verification_keys = array_values( array_filter( $this->verification_keys, fn ( $k ) => $k !== $encoded ) );
 		return true;
 	}
 

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -64,8 +64,26 @@ class DID {
 	 */
 	public function invalidate_verification_key( Key $key ) {
 		$encoded = $key->encode_private();
+
 		if ( ! in_array( $encoded, $this->verification_keys, true ) ) {
-			return false;
+			// Check for legacy-encoded keys too.
+			if ( str_starts_with( $encoded, Keys\PREFIX_CURVE_K256_PRIVATE ) ) {
+				$legacy_encoded = Keys\PREFIX_CURVE_K256 . substr( $encoded, strlen( Keys\PREFIX_CURVE_K256_PRIVATE ) );
+				if ( ! in_array( $legacy_encoded, $this->verification_keys, true ) ) {
+					return false;
+				}
+				$encoded = $legacy_encoded;
+			}
+			elseif ( str_starts_with( $encoded, Keys\PREFIX_CURVE_ED25519_PRIVATE ) ) {
+				$legacy_encoded = Keys\PREFIX_CURVE_ED25519 . substr( $encoded, strlen( Keys\PREFIX_CURVE_ED25519_PRIVATE ) );
+				if ( ! in_array( $legacy_encoded, $this->verification_keys, true ) ) {
+					return false;
+				}
+				$encoded = $legacy_encoded;
+			}
+			else {
+				return false;
+			}
 		}
 
 		$this->verification_keys = array_filter( $this->verification_keys, fn ( $k ) => $k !== $encoded );

--- a/inc/plc/class-operation.php
+++ b/inc/plc/class-operation.php
@@ -72,7 +72,7 @@ class Operation implements JsonSerializable {
 			throw new Exception( 'Verification methods are empty' );
 		}
 		foreach ( $this->verificationMethods as $id => $key ) {
-			if ( $id !== VERIFICATION_METHOD_ID ) {
+			if ( ! str_starts_with( $id, VERIFICATION_METHOD_PREFIX ) ) {
 				throw new Exception( sprintf( 'Invalid verification method ID: %s', $id ) );
 			}
 			if ( ! $key instanceof Key ) {
@@ -85,7 +85,7 @@ class Operation implements JsonSerializable {
 			if ( empty( $this->rotationKeys ) || empty( $this->verificationMethods ) ) {
 				throw new Exception( 'Missing rotationKeys or verificationMethods' );
 			}
-			if ( empty( $this->verificationMethods[ VERIFICATION_METHOD_ID ] ) ) {
+			if ( empty( $this->verificationMethods ) ) {
 				throw new Exception( 'Missing verification method for FAIR' );
 			}
 		}

--- a/inc/plc/class-operation.php
+++ b/inc/plc/class-operation.php
@@ -2,8 +2,8 @@
 
 namespace MiniFAIR\PLC;
 
-use Elliptic\EC\KeyPair;
 use MiniFAIR\Keys;
+use MiniFAIR\Keys\Key;
 use Exception;
 use JsonSerializable;
 
@@ -93,7 +93,7 @@ class Operation implements JsonSerializable {
 		return true;
 	}
 
-	public function sign( KeyPair $rotation_key ) : SignedOperation {
+	public function sign( Key $rotation_key ) : SignedOperation {
 		return sign_operation( $this, $rotation_key );
 	}
 

--- a/inc/plc/class-operation.php
+++ b/inc/plc/class-operation.php
@@ -62,21 +62,21 @@ class Operation implements JsonSerializable {
 		if ( empty( $this->rotationKeys ) ) {
 			throw new Exception( 'Rotation keys are empty' );
 		}
-		foreach ( $this->rotationKeys as $keypair ) {
-			if ( ! $keypair instanceof KeyPair ) {
-				throw new Exception( 'Rotation key is not a KeyPair object' );
+		foreach ( $this->rotationKeys as $key ) {
+			if ( ! $key instanceof Key ) {
+				throw new Exception( 'Rotation key is not a Key object' );
 			}
 		}
 
 		if ( empty( $this->verificationMethods ) ) {
 			throw new Exception( 'Verification methods are empty' );
 		}
-		foreach ( $this->verificationMethods as $key => $keypair ) {
-			if ( $key !== VERIFICATION_METHOD_ID ) {
-				throw new Exception( sprintf( 'Invalid verification method ID: %s', $key ) );
+		foreach ( $this->verificationMethods as $id => $key ) {
+			if ( $id !== VERIFICATION_METHOD_ID ) {
+				throw new Exception( sprintf( 'Invalid verification method ID: %s', $id ) );
 			}
-			if ( ! $keypair instanceof KeyPair ) {
-				throw new Exception( 'Rotation key is not a KeyPair object' );
+			if ( ! $key instanceof Key ) {
+				throw new Exception( 'Rotation key is not a Key object' );
 			}
 		}
 

--- a/inc/plc/namespace.php
+++ b/inc/plc/namespace.php
@@ -14,7 +14,7 @@ use MiniFAIR\Keys\Key;
 use WP_CLI;
 use YOCLIB\Multiformats\Multibase\Multibase;
 
-const VERIFICATION_METHOD_ID = 'fairpm';
+const VERIFICATION_METHOD_PREFIX = 'fair_';
 
 function bootstrap() {
 	add_action( 'init', __NAMESPACE__ . '\\register_types' );


### PR DESCRIPTION
Since only Ed25519 has widespread support in WP already, we want to use it for signing operations. Since https://github.com/bluesky-social/atproto/discussions/3928 we can now use these in the PLC directory (see https://github.com/did-method-plc/did-method-plc/pull/101), so we should be good to go.

Work in progress, needs extensive testing.