### PR TITLE
Add release_asset boolean

### DIFF
--- a/inc/api/class-metadatadocument.php
+++ b/inc/api/class-metadatadocument.php
@@ -10,6 +10,7 @@ class MetadataDocument implements JsonSerializable {
 	public string $name;
 	public string $slug;
 	public string $file;
+	public bool $release_asset;
 	public string $description;
 	public array $authors = [];
 	public string $license;
@@ -31,6 +32,7 @@ class MetadataDocument implements JsonSerializable {
 			'name' => $this->name,
 			'slug' => $this->slug,
 			'file' => $this->file,
+			'release_asset' => $this->release_asset,
 			'description' => $this->description,
 			'authors' => $this->authors,
 			'license' => $this->license,

--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -94,6 +94,7 @@ class Provider implements ProviderInterface {
 		$data->name = $package->name;
 		$data->slug = $package->slug;
 		$data->file = $package->file;
+		$data->release_asset = $package->release_asset;
 		$data->description = substr( strip_tags( trim( $package->sections['description'] ) ), 0, 139 ) . '…';
 		$data->license = 'GPL-2.0-or-later';
 		$data->keywords = $package->readme_tags ?? [];


### PR DESCRIPTION
Adds a release_asset boolean to the MetadataDocument endpoint. Some git hosts need additional data to download release assets. This simply lets us know if a release asset is used for the package.

Spec addition coming.

Signed-off-by: Andy Fragen <andy@thefragens.com>
