### PR TITLE
Skip dot org contributor data

### DIFF
--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -104,12 +104,12 @@ class Provider implements ProviderInterface {
 			'name' => $package->author,
 			'url' => $package->author_uri ??  '',
 		];
-		foreach ( $package->contributors as $contributor ) {
-			$data->authors[] = [
-				'name' => $contributor['display_name'],
-				'url' => $contributor['profile'],
-			];
-		}
+		//foreach ( $package->contributors as $contributor ) {
+		//	$data->authors[] = [
+		//		'name' => $contributor['display_name'],
+		//		'url' => $contributor['profile'],
+		//	];
+		//}
 
 		// Releases.
 		$data->releases = $this->get_release_data( $did, $package );


### PR DESCRIPTION
Section getting dot org contributor data as authors has been commented out. Since the data only displays the dot org username and a link to the WordPress profile page, it's not likely to be the data we want.

Currently we get data from the plugin headers of `Author` and `Author URI`.  There is not way to get the author's email at present.