### PR TITLE
Add security metadata

### DIFF
--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -96,6 +96,12 @@ class Provider implements ProviderInterface {
 		$data->filename = $package->file;
 		$data->description = substr( strip_tags( trim( $package->sections['description'] ) ), 0, 139 ) . '…';
 		$data->license = 'GPL-2.0-or-later';
+
+		// Parse security data.
+		$security = $package->security ?? '';
+		$security_key = is_email( $security ) ? 'email' : 'uri';
+		$data->security[][ $security_key ] = $package->security ?? '';
+
 		$data->keywords = $package->readme_tags ?? [];
 		$data->sections = $package->sections;
 


### PR DESCRIPTION
Adds security metadata from a plugin header `Security` with a value of an email address or a URI.