### PR TITLE
GU no longer uses rollback variable, use tags

### DIFF
--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -64,7 +64,7 @@ function update_fair_data( $repo, $repo_api ) : ?WP_Error {
 	}
 
 	$errors = [];
-	$versions = $repo_api->type->release_asset ? $repo_api->type->release_assets : $repo_api->type->rollback;
+	$versions = $repo_api->type->release_asset ? $repo_api->type->release_assets : $repo_api->type->tags;
 
 	foreach ( $versions as $tag => $url ) {
 		// This probably wants to be tied to the commit SHA, so that


### PR DESCRIPTION
GU was refactored to use `tags` and not `rollback` as the variable that holds the data here.