### PR TITLE
remove unexpected token in `inc/git-updater/class-provider.php`

### DIFF
--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -96,7 +96,7 @@ class Provider implements ProviderInterface {
 		$data->filename = $package->file;
 		$data->description = substr( strip_tags( trim( $package->sections['description'] ) ), 0, 139 ) . '…';
 		$data->license = $package->license ?? 'GPL-2.0-or-later';
-		$data->keywords = $package->readme_tags ? : array_values( $package->readme_tags ) : [];
+		$data->keywords = $package->readme_tags ? array_values( $package->readme_tags ) : [];
 		$data->sections = $package->sections;
 
 		// Parse link back out of author string.


### PR DESCRIPTION
I think this is supposed to be "if `$package->readme_tags` exists, store the array values in `$data->keywords`, otherwise store an empty array", but currently it's fataling because there's an extra `:`

Resubmitted from #33 
Duplicates #34 