### PR TITLE
Add 'packages' REST route

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -94,5 +94,9 @@ function get_package_data( WP_REST_Request $request ) {
 }
 
 function get_packages() {
-	return MiniFAIR\get_available_packages();
+	return array_filter( MiniFAIR\get_available_packages(),
+		function ( $package_did ) {
+			return null !== DID::get( $package_did );
+		}
+	);
 }


### PR DESCRIPTION
Adds the 'packages' REST route so the link in the MiniFAIR Settings page is functional.

<img width="918" height="248" alt="screenshot_704" src="https://github.com/user-attachments/assets/25905a4a-88a1-498a-b5c3-d0128a8410f5" />

https://fair.git-updater.com/wp-json/minifair/v1/packages

```
{
  "git-updater": "did:plc:afjf7gsjzsqmgc7dlhb553mv",
  "handbook-callout-blocks": "did:plc:deoui6ztyx6paqajconl67rz"
}
```

Possibly fixes #29 

I'm not quite sure what data is needed. 