### PR TITLE
Cache all remote API calls

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -129,6 +129,10 @@ function render_settings_page() {
 function fetch_did( DID $did ) {
 	$url = DID::DIRECTORY_API . '/' . $did->id;
 	$res = MiniFAIR\get_remote_url( $url );
+	if ( is_wp_error( $res ) ) {
+		return $res;
+	}
+
 	return json_decode( $res['body'], true );
 }
 

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -128,7 +128,7 @@ function render_settings_page() {
 
 function fetch_did( DID $did ) {
 	$url = DID::DIRECTORY_API . '/' . $did->id;
-	$res = MiniFAIR\get_remote_url( $url, __METHOD__ );
+	$res = MiniFAIR\get_remote_url( $url );
 	return json_decode( $res['body'], true );
 }
 

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -128,7 +128,7 @@ function render_settings_page() {
 
 function fetch_did( DID $did ) {
 	$url = DID::DIRECTORY_API . '/' . $did->id;
-	$res = wp_remote_get( $url );
+	$res = MiniFAIR\get_remote_url( $url, __METHOD__ );
 	return json_decode( $res['body'], true );
 }
 

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -82,7 +82,7 @@ function get_package_data( WP_REST_Request $request ) {
 		);
 	}
 
-	wp_cache_set( 'rest-endpoint-' . $id, $response, 'metadata-endpoints', MiniFAIR\CACHE_LIFETIME );
+	wp_cache_set( 'fair-metatdata-endpoint-' . $id, $response, 'metadata-endpoints', MiniFAIR\CACHE_LIFETIME );
 
 	return $response;
 }

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -82,5 +82,7 @@ function get_package_data( WP_REST_Request $request ) {
 		);
 	}
 
+	wp_cache_set( 'rest-endpoint-' . $id, $response, 'metadata-endpoints', MiniFAIR\CACHE_LIFETIME );
+
 	return $response;
 }

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -82,7 +82,7 @@ function get_package_data( WP_REST_Request $request ) {
 		);
 	}
 
-	wp_cache_set( 'fair-metatdata-endpoint-' . $id, $response, 'metadata-endpoints', MiniFAIR\CACHE_LIFETIME );
+	wp_cache_set( 'fair-metadata-endpoint-' . $id, $response, 'metadata-endpoints', MiniFAIR\CACHE_LIFETIME );
 
 	return $response;
 }

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -123,7 +123,7 @@ function generate_artifact_metadata( DID $did, $url ) {
 		$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 	}
 
-	$res = MiniFAIR\get_remote_url( $url, __METHOD__, $opt );
+	$res = MiniFAIR\get_remote_url( $url, $opt );
 
 	if ( 304 === $res['response']['code'] ) {
 		// Not modified, no need to update.

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -4,13 +4,12 @@ namespace MiniFAIR\Git_Updater;
 
 
 use Elliptic\EC\KeyPair;
+use MiniFAIR;
 use MiniFAIR\PLC;
 use MiniFAIR\PLC\DID;
 use MiniFAIR\PLC\Util;
 use stdClass;
 use WP_Error;
-
-const CACHE_PREFIX = 'minifair-';
 
 function bootstrap() : void {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_load' );
@@ -123,14 +122,8 @@ function generate_artifact_metadata( DID $did, $url ) {
 	if ( ! empty( $artifact_metadata ) && isset( $artifact_metadata['etag'] ) ) {
 		$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 	}
-	$res = wp_cache_get( CACHE_PREFIX . sha1( $url ) );
-	if ( ! $res ) {
-		$res = wp_remote_get( $url, $opt );
-		if ( is_wp_error( $res ) ) {
-			return $res;
-		}
-		wp_cache_set( CACHE_PREFIX . sha1( $url ), $res, '', 12 * HOUR_IN_SECONDS );
-	}
+
+	$res = MiniFAIR\get_remote_url( $url, __METHOD__, $opt );
 
 	if ( 304 === $res['response']['code'] ) {
 		// Not modified, no need to update.

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -124,6 +124,9 @@ function generate_artifact_metadata( DID $did, $url ) {
 	}
 
 	$res = MiniFAIR\get_remote_url( $url, $opt );
+	if ( is_wp_error( $res ) ) {
+		return $res;
+	}
 
 	if ( 304 === $res['response']['code'] ) {
 		// Not modified, no need to update.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -53,21 +53,20 @@ function get_package_metadata( DID $did ) {
 }
 
 /**
- * @throws Exception
  * @param string $url URL.
- * @param string $method Calling method.
  * @param array $opt wp_remote_get options.
- * @return stdClass
+ * @return array|WP_Error
  */
-function get_remote_url( $url, $method, $opt = null ) {
+function get_remote_url( $url, $opt = null ) {
 	$opt = $opt ?? [ 'headers' => [ 'Accept' => 'application/did+ld+json' ] ];
-	$response = wp_cache_get( CACHE_PREFIX . sha1( $url ) );
+	$cache_key = CACHE_PREFIX . sha1( $url );
+	$response = wp_cache_get( $cache_key );
 	if ( ! $response ) {
 		$response = wp_remote_get( $url, $opt );
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( "Error {$method}: " . $response->get_error_message() );
+			return $response;
 		}
-		wp_cache_set( CACHE_PREFIX . sha1( $url ), $response, '', CACHE_LIFETIME );
+		wp_cache_set( $cache_key, $response, '', CACHE_LIFETIME );
 	}
 
 	return $response;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -7,6 +7,7 @@ const CACHE_LIFETIME = 12 * HOUR_IN_SECONDS;
 
 use Exception;
 use MiniFAIR\PLC\DID;
+use WP_Error;
 
 function bootstrap() {
 	Admin\bootstrap();

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -4,6 +4,7 @@ namespace MiniFAIR\PLC;
 
 use Elliptic\EC\KeyPair;
 use Exception;
+use MiniFAIR;
 use MiniFAIR\API;
 use MiniFAIR\Keys;
 use WP_Post;
@@ -171,14 +172,7 @@ class DID {
 	 */
 	public function fetch_last_op() : Operation {
 		$url = sprintf( '%s/%s/log/last', static::DIRECTORY_API, $this->id );
-		$response = wp_remote_get( $url, [
-			'headers' => [
-				'Accept' => 'application/did+ld+json',
-			],
-		] );
-		if ( is_wp_error( $response ) ) {
-			throw new Exception( 'Error fetching last op: ' . $response->get_error_message() );
-		}
+		$response = MiniFAIR\get_remote_url( $url, __METHOD__ );
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
@@ -206,14 +200,7 @@ class DID {
 	 */
 	public function fetch_audit_log() {
 		$url = sprintf( '%s/%s/log/audit', static::DIRECTORY_API, $this->id );
-		$response = wp_remote_get( $url, [
-			'headers' => [
-				'Accept' => 'application/did+ld+json',
-			],
-		] );
-		if ( is_wp_error( $response ) ) {
-			return false;
-		}
+		$response = MiniFAIR\get_remote_url( $url, __METHOD__ );
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
@@ -223,29 +210,9 @@ class DID {
 		return $data;
 	}
 
-	public function refresh() {
-		// $url = sprintf( '%s/%s', static::DIRECTORY_API, $this->id );
-		// $response = wp_remote_get( $url, [
-		// 	'headers' => [
-		// 		'Accept' => 'application/did+ld+json',
-		// 	],
-		// ] );
-		// if ( is_wp_error( $response ) ) {
-		// 	return false;
-		// }
-	}
-
 	public function is_published() {
-		$this->refresh();
 		$url = sprintf( 'https://plc.directory/%s', $this->id );
-		$response = wp_remote_get( $url, [
-			'headers' => [
-				'Accept' => 'application/did+ld+json',
-			],
-		] );
-		if ( is_wp_error( $response ) ) {
-			return false;
-		}
+		$response = MiniFAIR\get_remote_url( $url, __METHOD__ );
 
 		// 404 = not found
 		// 410 = gone (tombstone)

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -7,6 +7,7 @@ use Exception;
 use MiniFAIR;
 use MiniFAIR\API;
 use MiniFAIR\Keys;
+use WP_Error;
 use WP_Post;
 
 class DID {
@@ -168,11 +169,14 @@ class DID {
 
 	/**
 	 * @throws Exception
-	 * @return Operation
+	 * @return Operation|WP_Error
 	 */
 	public function fetch_last_op() : Operation {
 		$url = sprintf( '%s/%s/log/last', static::DIRECTORY_API, $this->id );
 		$response = MiniFAIR\get_remote_url( $url );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( json_last_error() !== JSON_ERROR_NONE ) {

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -7,7 +7,6 @@ use Exception;
 use MiniFAIR;
 use MiniFAIR\API;
 use MiniFAIR\Keys;
-use WP_Error;
 use WP_Post;
 
 class DID {
@@ -129,9 +128,6 @@ class DID {
 	protected function prepare_update_op() : ?SignedOperation {
 		// Fetch the previous op.
 		$last_op = $this->fetch_last_op();
-		if ( is_wp_error( $last_op ) ) {
-			return $last_op;
-		}
 
 		// Get it as a CID.
 		$last_cid = cid_for_operation( $last_op );
@@ -172,13 +168,13 @@ class DID {
 
 	/**
 	 * @throws Exception
-	 * @return Operation|WP_Error
+	 * @return Operation
 	 */
 	public function fetch_last_op() : Operation {
 		$url = sprintf( '%s/%s/log/last', static::DIRECTORY_API, $this->id );
 		$response = MiniFAIR\get_remote_url( $url );
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			throw new Exception( 'Error fetching last op: ' . $response->get_error_message() );
 		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
@@ -209,7 +205,7 @@ class DID {
 		$url = sprintf( '%s/%s/log/audit', static::DIRECTORY_API, $this->id );
 		$response = MiniFAIR\get_remote_url( $url );
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return false;
 		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
@@ -227,7 +223,7 @@ class DID {
 		$url = sprintf( 'https://plc.directory/%s', $this->id );
 		$response = MiniFAIR\get_remote_url( $url );
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return false;
 		}
 
 		// 404 = not found

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -201,6 +201,9 @@ class DID {
 	public function fetch_audit_log() {
 		$url = sprintf( '%s/%s/log/audit', static::DIRECTORY_API, $this->id );
 		$response = MiniFAIR\get_remote_url( $url );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
@@ -210,9 +213,15 @@ class DID {
 		return $data;
 	}
 
+	/**
+	 * @return bool|WP_Error
+	 */
 	public function is_published() {
 		$url = sprintf( 'https://plc.directory/%s', $this->id );
 		$response = MiniFAIR\get_remote_url( $url );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
 		// 404 = not found
 		// 410 = gone (tombstone)

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -172,7 +172,7 @@ class DID {
 	 */
 	public function fetch_last_op() : Operation {
 		$url = sprintf( '%s/%s/log/last', static::DIRECTORY_API, $this->id );
-		$response = MiniFAIR\get_remote_url( $url, __METHOD__ );
+		$response = MiniFAIR\get_remote_url( $url );
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
@@ -200,7 +200,7 @@ class DID {
 	 */
 	public function fetch_audit_log() {
 		$url = sprintf( '%s/%s/log/audit', static::DIRECTORY_API, $this->id );
-		$response = MiniFAIR\get_remote_url( $url, __METHOD__ );
+		$response = MiniFAIR\get_remote_url( $url );
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
@@ -212,7 +212,7 @@ class DID {
 
 	public function is_published() {
 		$url = sprintf( 'https://plc.directory/%s', $this->id );
-		$response = MiniFAIR\get_remote_url( $url, __METHOD__ );
+		$response = MiniFAIR\get_remote_url( $url );
 
 		// 404 = not found
 		// 410 = gone (tombstone)

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -129,6 +129,9 @@ class DID {
 	protected function prepare_update_op() : ?SignedOperation {
 		// Fetch the previous op.
 		$last_op = $this->fetch_last_op();
+		if ( is_wp_error( $last_op ) ) {
+			return $last_op;
+		}
 
 		// Get it as a CID.
 		$last_cid = cid_for_operation( $last_op );


### PR DESCRIPTION
This PR caches all the remote API calls in Mini FAIR. Many of these API calls are called on each page load and for every package version, specifically `generate_artifact_metadata()` which was already cached. This caches all the other API requests.

An `Exception` is thrown for errors.