### PR TITLE
Composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fairpm/mini-fair-repo",
-    "description": "Mini Fair Repository - A WordPress plugin for decentralized content management",
+    "description": "Transform your WP site into a FAIR Package Management Repository",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
     "version": "0.1.0",


### PR DESCRIPTION
The mini-fair-repo's composer.json is missing the name field, which is required for Composer to install it as a package.

This PR adds the name and updates composer