### PR TITLE
Only cache responses when necessary

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -128,7 +128,7 @@ function render_settings_page() {
 
 function fetch_did( DID $did ) {
 	$url = DID::DIRECTORY_API . '/' . $did->id;
-	$res = MiniFAIR\get_remote_url( $url );
+	$res = MiniFAIR\get_remote_json( $url );
 	if ( is_wp_error( $res ) ) {
 		return $res;
 	}

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -126,6 +126,12 @@ function render_settings_page() {
 	<?php
 }
 
+/**
+ * Fetch the raw data for the DID document.
+ *
+ * @internal This is intentionally uncached, as need the latest data for the DID.
+ * @return stdClass|WP_Error
+ */
 function fetch_did( DID $did ) {
 	$url = DID::DIRECTORY_API . '/' . $did->id;
 	$res = MiniFAIR\get_remote_json( $url );

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -117,8 +117,8 @@ function generate_artifact_metadata( DID $did, $url ) {
 	$artifact_metadata = get_option( 'minifair_artifact_' . $artifact_id, null );
 
 	$cache_key = CACHE_PREFIX . sha1( $url );
-	$cached_artifact = wp_cache_get( $cache_key );
-	if ( ! $cached_artifact ) {
+	$res = wp_cache_get( $cache_key );
+	if ( ! $res ) {
 		// Fetch the artifact.
 		$opt = [
 			'headers' => [

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -123,7 +123,7 @@ function generate_artifact_metadata( DID $did, $url ) {
 		$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 	}
 
-	$res = MiniFAIR\get_remote_url( $url, $opt );
+	$res = MiniFAIR\get_remote_json( $url, $opt );
 	if ( is_wp_error( $res ) ) {
 		return $res;
 	}

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -129,7 +129,7 @@ function generate_artifact_metadata( DID $did, $url ) {
 			$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 		}
 
-		$res = MiniFAIR\get_remote_json( $url, $opt );
+		$res = wp_remote_get( $url, $opt );
 		if ( is_wp_error( $res ) ) {
 			return $res;
 		}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -58,17 +58,7 @@ function get_package_metadata( DID $did ) {
  * @param array $opt wp_remote_get options.
  * @return array|WP_Error
  */
-function get_remote_url( $url, $opt = null ) {
-	$opt = $opt ?? [ 'headers' => [ 'Accept' => 'application/did+ld+json' ] ];
-	$cache_key = CACHE_PREFIX . sha1( $url );
-	$response = wp_cache_get( $cache_key );
-	if ( ! $response ) {
-		$response = wp_remote_get( $url, $opt );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-		wp_cache_set( $cache_key, $response, '', CACHE_LIFETIME );
-	}
-
-	return $response;
+function get_remote_json( $url, $opt = [] ) {
+	$opt['headers']['Accept'] ??= 'application/did+ld+json';
+	return wp_remote_get( $url, $opt );
 }

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -172,7 +172,7 @@ class DID {
 	 */
 	public function fetch_last_op() : Operation {
 		$url = sprintf( '%s/%s/log/last', static::DIRECTORY_API, $this->id );
-		$response = MiniFAIR\get_remote_url( $url );
+		$response = MiniFAIR\get_remote_json( $url );
 		if ( is_wp_error( $response ) ) {
 			throw new Exception( 'Error fetching last op: ' . $response->get_error_message() );
 		}
@@ -203,7 +203,7 @@ class DID {
 	 */
 	public function fetch_audit_log() {
 		$url = sprintf( '%s/%s/log/audit', static::DIRECTORY_API, $this->id );
-		$response = MiniFAIR\get_remote_url( $url );
+		$response = MiniFAIR\get_remote_json( $url );
 		if ( is_wp_error( $response ) ) {
 			return false;
 		}
@@ -221,7 +221,7 @@ class DID {
 	 */
 	public function is_published() {
 		$url = sprintf( 'https://plc.directory/%s', $this->id );
-		$response = MiniFAIR\get_remote_url( $url );
+		$response = MiniFAIR\get_remote_json( $url );
 		if ( is_wp_error( $response ) ) {
 			return false;
 		}

--- a/inc/plc/class-did.php
+++ b/inc/plc/class-did.php
@@ -167,6 +167,11 @@ class DID {
 	}
 
 	/**
+	 * Fetch the last operation on the DID.
+	 *
+	 * This is used to build the `prev` when we're running updates.
+	 *
+	 * @internal This is intentionally uncached, as need the latest data for the DID.
 	 * @throws Exception
 	 * @return Operation
 	 */
@@ -199,6 +204,9 @@ class DID {
 	}
 
 	/**
+	 * Fetch the audit log for this DID.
+	 *
+	 * @internal This is intentionally uncached, as need the latest data for the DID.
 	 * @return array|WP_Error
 	 */
 	public function fetch_audit_log() {
@@ -217,6 +225,9 @@ class DID {
 	}
 
 	/**
+	 * Check if the DID has been published.
+	 *
+	 * @internal This is intentionally uncached, as need the latest data for the DID.
 	 * @return bool|WP_Error
 	 */
 	public function is_published() {


### PR DESCRIPTION
See #48, #50

This PR:
- Removes caching from `MiniFAIR\get_remote_url()`.
- Implements caching directly in `MiniFAIR\Git_Updater\generate_artifact_metadata()`.
- Renames `MiniFAIR\get_remote_url()` to `MiniFAIR\get_remote_json()` for clarity, and updates references.
- Adds docblock entries from Ryan.