### PR TITLE
Switch to SHA-384 hashes for signature generation

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -64,7 +64,6 @@ function get_package_data( WP_REST_Request $request ) {
 
 	$did = DID::get( $id );
 	if ( empty( $did ) ) {
-		echo 'wat';
 		return new WP_Error(
 			'minifair.get_package.not_found',
 			__( 'Package not found.', 'minifair' ),

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -165,10 +165,9 @@ function generate_artifact_metadata( DID $did, string $url, $force_regenerate = 
 
 function sign_artifact_data( Key $key, $data ) {
 	// Hash, then sign the hash.
-	$hash = hash( 'sha256', $data, false );
+	$hash = hash( 'sha384', $data, false );
 	$signature = $key->sign( $hash );
 
-	// Convert to compact (IEEE-P1363) form, then to base64url.
 	$compact = hex2bin( $signature );
 	return Util\base64url_encode( $compact );
 }


### PR DESCRIPTION
SHA-384 (truncated SHA-512) is generally more secure than SHA-256 due to the larger digests. This also matches WP core's signature check, allowing us to reuse the existing code.