### PR TITLE
Explicitly set Accept header for release asset when creating artifact metadata

### DIFF
--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -252,7 +252,7 @@ class Provider implements ProviderInterface {
 		foreach ( $versions as $tag => $url ) {
 			// This probably wants to be tied to the commit SHA, so that
 			// if tags are changed, we refresh automatically.
-			$data = generate_artifact_metadata( $did, $url, $force_regenerate );
+			$data = generate_artifact_metadata( $did, $url, $repo_api->type->release_asset, $force_regenerate );
 			if ( is_wp_error( $data ) ) {
 				$errors[] = $data;
 			}

--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -252,7 +252,7 @@ class Provider implements ProviderInterface {
 		foreach ( $versions as $tag => $url ) {
 			// This probably wants to be tied to the commit SHA, so that
 			// if tags are changed, we refresh automatically.
-			$data = generate_artifact_metadata( $did, $url, $repo_api->type->release_asset, $force_regenerate );
+			$data = generate_artifact_metadata( $did, $url, $force_regenerate );
 			if ( is_wp_error( $data ) ) {
 				$errors[] = $data;
 			}

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -126,13 +126,9 @@ function generate_artifact_metadata( DID $did, string $url, $force_regenerate = 
 	$artifact_metadata = get_option( 'minifair_artifact_' . $artifact_id, null );
 
 	// Fetch the artifact.
-	if ( str_contains( $url, 'api.github.com' ) && str_contains( $url, 'releases/assets' ) ) {
-		// For release assets, we want the raw binary.
-		$opt = [ 'headers' => [ 'Accept' => 'application/octet-stream' ] ];
-	} else {
-		// For source archives, we want the archive file.
-		$opt = [ 'headers' => [ 'Accept' => 'application/vnd.github+json' ] ];
-	}
+	$opt = str_contains( $url, 'api.github.com' ) && str_contains( $url, 'releases/assets' )
+		? [ 'headers' => [ 'Accept' => 'application/octet-stream' ] ]
+		: [];
 	if ( ! $force_regenerate && ! empty( $artifact_metadata ) && isset( $artifact_metadata['etag'] ) ) {
 		$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 	}

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -66,7 +66,7 @@ function update_fair_data( $repo, $repo_api ) : ?WP_Error {
 	foreach ( $versions as $tag => $url ) {
 		// This probably wants to be tied to the commit SHA, so that
 		// if tags are changed, we refresh automatically.
-		$data = generate_artifact_metadata( $did, $url );
+		$data = generate_artifact_metadata( $did, $url, $repo->release_asset );
 		if ( is_wp_error( $data ) ) {
 			$errors[] = $data;
 		}
@@ -101,10 +101,11 @@ function get_artifact_metadata( DID $did, $url ) {
 /**
  * @param DID $did
  * @param string $url
+ * @param boolean $release_asset True if this is a release asset, false if it's a source archive.
  * @param boolean $force_regenerate True to skip cache.
  * @return array|WP_Error
  */
-function generate_artifact_metadata( DID $did, string $url, $force_regenerate = false ) {
+function generate_artifact_metadata( DID $did, string $url, $release_asset = false, $force_regenerate = false ) {
 	$keys = $did->get_verification_keys();
 	if ( empty( $keys ) ) {
 		return new WP_Error(
@@ -126,11 +127,7 @@ function generate_artifact_metadata( DID $did, string $url, $force_regenerate = 
 	$artifact_metadata = get_option( 'minifair_artifact_' . $artifact_id, null );
 
 	// Fetch the artifact.
-	$opt = [
-		'headers' => [
-			'Accept' => 'application/octet-stream;q=1.0, */*;q=0.7',
-		],
-	];
+	$opt = $release_asset ? [ 'headers' => [ 'Accept' => 'application/octet-stream' ] ] : [];
 	if ( ! $force_regenerate && ! empty( $artifact_metadata ) && isset( $artifact_metadata['etag'] ) ) {
 		$opt['headers']['If-None-Match'] = $artifact_metadata['etag'];
 	}

--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -29,9 +29,6 @@ function on_load() : void {
  * @param object $repo_api Repository API object.
  */
 function update_on_get_remote_meta( stdClass $repo, $repo_api ) : void {
-	global $release_asset;
-
-	$release_asset = $repo->release_asset ?? false;
 	$err = update_fair_data( $repo, $repo_api );
 	if ( is_wp_error( $err ) ) {
 		// Log the error.
@@ -108,8 +105,6 @@ function get_artifact_metadata( DID $did, $url ) {
  * @return array|WP_Error
  */
 function generate_artifact_metadata( DID $did, string $url, $force_regenerate = false ) {
-	global $release_asset;
-
 	$keys = $did->get_verification_keys();
 	if ( empty( $keys ) ) {
 		return new WP_Error(
@@ -131,7 +126,7 @@ function generate_artifact_metadata( DID $did, string $url, $force_regenerate = 
 	$artifact_metadata = get_option( 'minifair_artifact_' . $artifact_id, null );
 
 	// Fetch the artifact.
-	if ( $release_asset ) {
+	if ( str_contains( $url, 'api.github.com' ) && str_contains( $url, 'releases/assets' ) ) {
 		// For release assets, we want the raw binary.
 		$opt = [ 'headers' => [ 'Accept' => 'application/octet-stream' ] ];
 	} else {


### PR DESCRIPTION
It seems that a weighted Accept header doesn't work with GitHub. Explicitly setting the Accept header seems to be more consistent. In order to accomplish this I needed to add a parameter to `generate_artifact_metadata()`.