### PR TITLE
Register the Git Updater provider only if the plugin is active

### DIFF
--- a/inc/git-updater/namespace.php
+++ b/inc/git-updater/namespace.php
@@ -6,6 +6,7 @@ use MiniFAIR;
 use MiniFAIR\Keys\Key;
 use MiniFAIR\PLC\DID;
 use MiniFAIR\PLC\Util;
+use MiniFAIR\Provider as ProviderInterface;
 use stdClass;
 use WP_Error;
 
@@ -19,7 +20,22 @@ function on_load() : void {
 		return;
 	}
 
+	add_filter( 'minifair.providers', __NAMESPACE__ . '\\register_provider' ) ;
 	add_action( 'get_remote_repo_meta', __NAMESPACE__ . '\\update_on_get_remote_meta', 20, 2 ) ;
+}
+
+/**
+ * Registers the Git Updater provider.
+ *
+ * @param array<string, ProviderInterface> $providers The previously registered providers.
+ *
+ * @return array<string, ProviderInterface>
+ */
+function register_provider( array $providers ): array {
+    return [
+        ...$providers,
+        Provider::TYPE => new Provider(),
+    ];
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,7 +17,7 @@ function bootstrap() {
 }
 
 /**
- * @return Provider[]
+ * @return array<string, Provider>
  */
 function get_providers() : array {
 	static $providers = [];
@@ -25,10 +25,8 @@ function get_providers() : array {
 		return $providers;
 	}
 
-	$providers = [
-		Git_Updater\Provider::TYPE => new Git_Updater\Provider(),
-	];
-	$providers = apply_filters( 'minifair.providers', $providers );
+	$providers = apply_filters( 'minifair.providers', [] );
+
 	return $providers;
 }
 


### PR DESCRIPTION
This PR defers Git Updater provider registration until the plugin is available and active. Resolves #55.