### PR TITLE
Correct the example MetadataDocument types

### DIFF
--- a/inc/api/class-metadatadocument.php
+++ b/inc/api/class-metadatadocument.php
@@ -23,7 +23,7 @@ class MetadataDocument implements JsonSerializable {
 	/**
 	 * Package type.
 	 *
-	 * Example: 'wp-plugins' or 'wp-themes'.
+	 * Example: 'wp-plugin' or 'wp-theme'.
 	 *
 	 * @var string
 	 */


### PR DESCRIPTION
This data ultimately comes from [here](https://github.com/afragen/git-updater/blob/cf19365291fd274a7e90c7f903a8c40f30d405a0/src/Git_Updater/Plugin.php#L175) and [here](https://github.com/afragen/git-updater/blob/cf19365291fd274a7e90c7f903a8c40f30d405a0/src/Git_Updater/Theme.php#L191) in Git Updater which uses the singular form. [And here is the spec](https://github.com/fairpm/fair-protocol/blob/main/registry.md#package-types).