### PR TITLE
make vendor/autoload.php optional for Bedrock installs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.php]
+; WPCS requires tabs for indent
+indent_style = tab

--- a/plugin.php
+++ b/plugin.php
@@ -22,7 +22,9 @@ require __DIR__ . '/inc/keys/namespace.php';
 require __DIR__ . '/inc/plc/namespace.php';
 require __DIR__ . '/inc/plc/util.php';
 
-// A composer-based install of this plugin will not have a local vendor/ dir, nor does it need one.
-@include __DIR__ . '/vendor/autoload.php';
+// We may already be autoloaded in a composer based setup such as Bedrock, so avoid duplicates if so
+if ( ! interface_exists( FAIR\Beacon\Provider::class ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
 
 bootstrap();

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,8 @@ require __DIR__ . '/inc/git-updater/namespace.php';
 require __DIR__ . '/inc/keys/namespace.php';
 require __DIR__ . '/inc/plc/namespace.php';
 require __DIR__ . '/inc/plc/util.php';
-require __DIR__ . '/vendor/autoload.php';
+
+// A composer-based install of this plugin will not have a local vendor/ dir, nor does it need one.
+@include __DIR__ . '/vendor/autoload.php';
 
 bootstrap();

--- a/plugin.php
+++ b/plugin.php
@@ -24,7 +24,7 @@ require __DIR__ . '/inc/plc/util.php';
 
 // We may already be autoloaded in a composer based setup such as Bedrock, so avoid duplicates if so.
 if ( ! interface_exists( FAIR\Beacon\Provider::class ) ) {
-    require_once __DIR__ . '/vendor/autoload.php';
+	require_once __DIR__ . '/vendor/autoload.php';
 }
 
 bootstrap();

--- a/plugin.php
+++ b/plugin.php
@@ -22,7 +22,7 @@ require __DIR__ . '/inc/keys/namespace.php';
 require __DIR__ . '/inc/plc/namespace.php';
 require __DIR__ . '/inc/plc/util.php';
 
-// We may already be autoloaded in a composer based setup such as Bedrock, so avoid duplicates if so
+// We may already be autoloaded in a composer based setup such as Bedrock, so avoid duplicates if so.
 if ( ! interface_exists( FAIR\Beacon\Provider::class ) ) {
     require_once __DIR__ . '/vendor/autoload.php';
 }


### PR DESCRIPTION
When I install fair-beacon direct from github, as fair-site does, the plugin comes without a vendor/ directory. so the autoloader import during the plugin's loading is broken.  Thing is, it doesn't need one, because the transitive dependencies have all been slurped up by composer and put in the root vendor/ directory anyway.  

The current version of fair-site doesn't import the autoloader til fairly late, but even then it should be active by the time the plugin is actually used.  The Bedrock version I'm working on loads it even earlier, so it should never be an issue.   And if one is working with a non-composer setup and a git checkout of fair-beacon, they'll have to run `composer update` in the plugin dir anyway: the error about a missing filename is replaced by an error about a missing class, and it should already be familiar to anyone who's used composer.