### PR TITLE
Limit releases to last 10 versions

### DIFF
--- a/inc/git-updater/class-provider.php
+++ b/inc/git-updater/class-provider.php
@@ -185,6 +185,9 @@ class Provider implements ProviderInterface {
 		$images = [];
 		$versions = $package->release_asset ? $package->release_assets : $package->tags;
 
+		// Limit to latest 10 versions.
+		$versions = array_slice( (array) $versions, 0, 10, true );
+
 		// Banners and icons.
 		$other_assets = [
 			'banner' => $package->banners,


### PR DESCRIPTION
No reason to have last 30. This was default limit from GitHub